### PR TITLE
Update NBA API host to paid endpoint

### DIFF
--- a/find_more_players.py
+++ b/find_more_players.py
@@ -17,7 +17,7 @@ def find_player_ids():
     api_key = os.getenv('RAPIDAPI_KEY')
     headers = {
         'X-RapidAPI-Key': api_key,
-        'X-RapidAPI-Host': 'nba-api-free-data.p.rapidapi.com'
+        'X-RapidAPI-Host': 'nba-api-data.p.rapidapi.com'
     }
     
     # Let's try some common player ID ranges based on your working ID (4869342)
@@ -38,7 +38,7 @@ def find_player_ids():
     
     for player_id in test_ids:
         try:
-            url = f"https://nba-api-free-data.p.rapidapi.com/nba-player-stats"
+            url = f"https://nba-api-data.p.rapidapi.com/nba-player-stats"
             params = {'playerid': player_id}
             
             response = requests.get(url, headers=headers, params=params, timeout=10)

--- a/scripts_backup/load_all_nba_players.py
+++ b/scripts_backup/load_all_nba_players.py
@@ -29,10 +29,10 @@ class FullScaleNBALoader:
     
     def __init__(self):
         self.api_key = os.getenv('RAPIDAPI_KEY')
-        self.base_url = "https://nba-api-free-data.p.rapidapi.com"
+        self.base_url = "https://nba-api-data.p.rapidapi.com"
         self.headers = {
             'X-RapidAPI-Key': self.api_key,
-            'X-RapidAPI-Host': 'nba-api-free-data.p.rapidapi.com'
+            'X-RapidAPI-Host': 'nba-api-data.p.rapidapi.com'
         }
         
         self.divisions = [

--- a/scripts_backup/load_nba_complete.py
+++ b/scripts_backup/load_nba_complete.py
@@ -28,10 +28,10 @@ class CompleteNBALoader:
     
     def __init__(self):
         self.api_key = os.getenv('RAPIDAPI_KEY')
-        self.base_url = "https://nba-api-free-data.p.rapidapi.com"
+        self.base_url = "https://nba-api-data.p.rapidapi.com"
         self.headers = {
             'X-RapidAPI-Key': self.api_key,
-            'X-RapidAPI-Host': 'nba-api-free-data.p.rapidapi.com'
+            'X-RapidAPI-Host': 'nba-api-data.p.rapidapi.com'
         }
         
         # NBA divisions

--- a/scripts_backup/load_nba_corrected.py
+++ b/scripts_backup/load_nba_corrected.py
@@ -30,10 +30,10 @@ class CorrectedNBALoader:
     
     def __init__(self):
         self.api_key = os.getenv('RAPIDAPI_KEY')
-        self.base_url = "https://nba-api-free-data.p.rapidapi.com"
+        self.base_url = "https://nba-api-data.p.rapidapi.com"
         self.headers = {
             'X-RapidAPI-Key': self.api_key,
-            'X-RapidAPI-Host': 'nba-api-free-data.p.rapidapi.com'
+            'X-RapidAPI-Host': 'nba-api-data.p.rapidapi.com'
         }
         
         self.divisions = [

--- a/scripts_backup/load_nba_fixed.py
+++ b/scripts_backup/load_nba_fixed.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-NBA Data Loader using NBA API Free Data (nba-api-free-data.p.rapidapi.com)
+NBA Data Loader using NBA API (nba-api-data.p.rapidapi.com)
 Follows the correct API pattern: divisions -> teams -> players -> player stats
 """
 
@@ -31,10 +31,10 @@ class NBAFreeDataLoader:
     def __init__(self):
         self.api_key = os.getenv('RAPIDAPI_KEY')
         self.console = Console()
-        self.base_url = "https://nba-api-free-data.p.rapidapi.com"
+        self.base_url = "https://nba-api-data.p.rapidapi.com"
         self.headers = {
             'X-RapidAPI-Key': self.api_key,
-            'X-RapidAPI-Host': 'nba-api-free-data.p.rapidapi.com'
+            'X-RapidAPI-Host': 'nba-api-data.p.rapidapi.com'
         }
         
         # NBA divisions - CORRECTED URLs (all follow same pattern as atlantic)

--- a/scripts_backup/load_nba_fixed_langgraph.py
+++ b/scripts_backup/load_nba_fixed_langgraph.py
@@ -30,10 +30,10 @@ class FixedNBALoader:
     
     def __init__(self):
         self.api_key = os.getenv('RAPIDAPI_KEY')
-        self.base_url = "https://nba-api-free-data.p.rapidapi.com"
+        self.base_url = "https://nba-api-data.p.rapidapi.com"
         self.headers = {
             'X-RapidAPI-Key': self.api_key,
-            'X-RapidAPI-Host': 'nba-api-free-data.p.rapidapi.com'
+            'X-RapidAPI-Host': 'nba-api-data.p.rapidapi.com'
         }
         
         self.divisions = [

--- a/scripts_backup/load_nba_langchain_agents.py
+++ b/scripts_backup/load_nba_langchain_agents.py
@@ -60,10 +60,10 @@ class LangChainNBALoader:
     def __init__(self):
         self.api_key = os.getenv('RAPIDAPI_KEY')
         self.openai_key = os.getenv('OPENAI_API_KEY')
-        self.base_url = "https://nba-api-free-data.p.rapidapi.com"
+        self.base_url = "https://nba-api-data.p.rapidapi.com"
         self.headers = {
             'X-RapidAPI-Key': self.api_key,
-            'X-RapidAPI-Host': 'nba-api-free-data.p.rapidapi.com'
+            'X-RapidAPI-Host': 'nba-api-data.p.rapidapi.com'
         }
         
         # Initialize LangChain components

--- a/scripts_backup/load_nba_langgraph.py
+++ b/scripts_backup/load_nba_langgraph.py
@@ -51,10 +51,10 @@ class LangGraphNBALoader:
     def __init__(self):
         self.api_key = os.getenv('RAPIDAPI_KEY')
         self.openai_key = os.getenv('OPENAI_API_KEY')
-        self.base_url = "https://nba-api-free-data.p.rapidapi.com"
+        self.base_url = "https://nba-api-data.p.rapidapi.com"
         self.headers = {
             'X-RapidAPI-Key': self.api_key,
-            'X-RapidAPI-Host': 'nba-api-free-data.p.rapidapi.com'
+            'X-RapidAPI-Host': 'nba-api-data.p.rapidapi.com'
         }
         
         # Initialize LangChain components

--- a/scripts_backup/load_nba_with_langchain.py
+++ b/scripts_backup/load_nba_with_langchain.py
@@ -88,10 +88,10 @@ class NBADataFetcher:
                 'headers': {}  # No auth required
             },
             'nba_free_data': {
-                'base_url': 'https://nba-api-free-data.p.rapidapi.com',
+                'base_url': 'https://nba-api-data.p.rapidapi.com',
                 'headers': {
                     'X-RapidAPI-Key': self.rapidapi_key,
-                    'X-RapidAPI-Host': 'nba-api-free-data.p.rapidapi.com'
+                    'X-RapidAPI-Host': 'nba-api-data.p.rapidapi.com'
                 }
             }
         }

--- a/scripts_backup/load_nba_working.py
+++ b/scripts_backup/load_nba_working.py
@@ -28,10 +28,10 @@ class WorkingNBALoader:
     
     def __init__(self):
         self.api_key = os.getenv('RAPIDAPI_KEY')
-        self.base_url = "https://nba-api-free-data.p.rapidapi.com"
+        self.base_url = "https://nba-api-data.p.rapidapi.com"
         self.headers = {
             'X-RapidAPI-Key': self.api_key,
-            'X-RapidAPI-Host': 'nba-api-free-data.p.rapidapi.com'
+            'X-RapidAPI-Host': 'nba-api-data.p.rapidapi.com'
         }
         
         # NBA divisions

--- a/src/sports_bot/config/api_config.py
+++ b/src/sports_bot/config/api_config.py
@@ -282,7 +282,7 @@ legacy_api_config = {
         }
     },
     'NBA': {
-        'base_url': 'https://nba-api-free-data.p.rapidapi.com/',
+        'base_url': 'https://nba-api-data.p.rapidapi.com/',
         'endpoints': {
             # Player endpoints - corrected based on user feedback
             'PlayerInfo': 'nba-player-info',                # Expects ?playerid={player_id}
@@ -306,7 +306,7 @@ legacy_api_config = {
         },
         'headers': {
             'X-RapidAPI-Key': RAPIDAPI_KEY,
-            'X-RapidAPI-Host': 'nba-api-free-data.p.rapidapi.com'
+            'X-RapidAPI-Host': 'nba-api-data.p.rapidapi.com'
         }
     }
 }

--- a/src/sports_bot/langchain_integration/sport_registry.py
+++ b/src/sports_bot/langchain_integration/sport_registry.py
@@ -211,9 +211,18 @@ class SportRegistry:
             api_config={
                 "base_url": "https://nba-api-data.p.rapidapi.com",
                 "endpoints": {
-                    "AllTeams": "/teams",
-                    "PlayerStats": "/player-stats",
-                    "TeamRoster": "/team-roster"
+                    "PlayerInfo": "/nba-player-info",
+                    "PlayerStats": "/nba-player-stats",
+                    "PlayerStatsSummary": "/nba-player-stats-summary",
+                    "PlayersByTeam": "/nba-player-list",
+                    "TeamInfo": "/nba-team-info",
+                    "TeamStats": "/nba-team-stats",
+                    "AllTeams": "/nba-teams",
+                    "TeamsList": "/nba-team-list",
+                    "LeagueInfo": "/nba-league-info",
+                    "Standings": "/nba-standings",
+                    "GameSchedule": "/nba-games",
+                    "PlayerGamelog": "/nba-player-gamelog",
                 },
                 "headers": {
                     "X-RapidAPI-Host": "nba-api-data.p.rapidapi.com"

--- a/test_nba_api.py
+++ b/test_nba_api.py
@@ -26,14 +26,14 @@ def test_nba_api():
     
     headers = {
         'X-RapidAPI-Key': api_key,
-        'X-RapidAPI-Host': 'nba-api-free-data.p.rapidapi.com'
+        'X-RapidAPI-Host': 'nba-api-data.p.rapidapi.com'
     }
     
     # Test URLs
     test_urls = [
-        'https://nba-api-free-data.p.rapidapi.com/nba-atlantic-team-list',
-        'https://nba-api-free-data.p.rapidapi.com/nba-central-team-list',
-        'https://nba-api-free-data.p.rapidapi.com/nba-player-stats?playerid=4869342'
+        'https://nba-api-data.p.rapidapi.com/nba-atlantic-team-list',
+        'https://nba-api-data.p.rapidapi.com/nba-central-team-list',
+        'https://nba-api-data.p.rapidapi.com/nba-player-stats?playerid=4869342'
     ]
     
     for url in test_urls:

--- a/test_team_endpoints.py
+++ b/test_team_endpoints.py
@@ -25,11 +25,11 @@ def test_team_endpoints():
     
     headers = {
         'X-RapidAPI-Key': api_key,
-        'X-RapidAPI-Host': 'nba-api-free-data.p.rapidapi.com'
+        'X-RapidAPI-Host': 'nba-api-data.p.rapidapi.com'
     }
-    
+
     # Test just one division first
-    test_url = 'https://nba-api-free-data.p.rapidapi.com/nba-atlantic-team-list'
+    test_url = 'https://nba-api-data.p.rapidapi.com/nba-atlantic-team-list'
     
     console.print(f"[bold blue]Testing: {test_url}[/bold blue]")
     


### PR DESCRIPTION
## Summary
- switch NBA API base URL and host to `nba-api-data.p.rapidapi.com`
- update configuration, tests and sample scripts

## Testing
- `pytest -q` *(fails: ModuleNotFoundError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_6865c886ad0c8324a507c6086ca34116