### PR TITLE
Replace mock contexts with real QueryContext

### DIFF
--- a/src/sports_bot/langchain_integration/workflows.py
+++ b/src/sports_bot/langchain_integration/workflows.py
@@ -5,29 +5,34 @@ This module implements the LangGraph workflows recommended in the architectural 
 for complex sports analysis tasks like league leaders, player rankings, and debates.
 """
 
-from typing import Dict, Any, List, Optional, TypedDict, Annotated
-from langgraph.graph import StateGraph, END
-from langgraph.prebuilt import ToolNode
-from langchain_core.messages import HumanMessage, AIMessage, SystemMessage
-from langchain_openai import ChatOpenAI
 import asyncio
+from typing import Annotated, Any, Dict, List, Optional, TypedDict
 
+import requests
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+from langchain_openai import ChatOpenAI
+from langgraph.graph import END, StateGraph
+from langgraph.prebuilt import ToolNode
+
+from sports_bot.cache.shared_cache import get_cache_instance
+from sports_bot.config.api_config import api_config
 from sports_bot.langchain_integration.tools import (
-    SPORTS_TOOLS, 
-    SportContext,
+    SPORTS_TOOLS,
     FetchPlayerStatsTool,
     FetchTeamListingTool,
-    FuzzyPlayerSearchTool
+    FuzzyPlayerSearchTool,
+    SportContext,
 )
 
 
 class WorkflowState(TypedDict):
     """
     Shared state for LangGraph workflows.
-    
+
     This implements the "shared state mechanism" mentioned in the architectural review,
     allowing agents to collaborate dynamically and track context across the workflow.
     """
+
     messages: List[Dict[str, Any]]
     sport: str
     season: Optional[str]
@@ -46,7 +51,7 @@ class WorkflowState(TypedDict):
 class LeagueLeadersWorkflow:
     """
     LangGraph workflow for League Leaders queries.
-    
+
     This implements the comprehensive workflow described in the architectural review:
     1. Initial Node: Extract desired statistic
     2. Team Fetch Node: Get all teams
@@ -55,20 +60,20 @@ class LeagueLeadersWorkflow:
     5. Aggregation Node: Filter, aggregate, and sort
     6. Response Formatting Node: Format results
     """
-    
+
     def __init__(self, llm_model: str = "gpt-4o-mini"):
         self.llm = ChatOpenAI(model=llm_model, temperature=0)
         self.tools = SPORTS_TOOLS
         self.tool_node = ToolNode(self.tools)
-        
+
         # Build the workflow graph
         self.workflow = self._build_workflow()
-    
+
     def _build_workflow(self) -> StateGraph:
         """Build the LangGraph workflow for league leaders"""
-        
+
         workflow = StateGraph(WorkflowState)
-        
+
         # Add nodes
         workflow.add_node("extract_query", self._extract_query_details)
         workflow.add_node("fetch_teams", self._fetch_teams)
@@ -76,7 +81,7 @@ class LeagueLeadersWorkflow:
         workflow.add_node("aggregate_stats", self._aggregate_stats)
         workflow.add_node("format_response", self._format_response)
         workflow.add_node("tools", self.tool_node)
-        
+
         # Define the flow
         workflow.set_entry_point("extract_query")
         workflow.add_edge("extract_query", "fetch_teams")
@@ -84,156 +89,207 @@ class LeagueLeadersWorkflow:
         workflow.add_edge("fetch_player_data", "aggregate_stats")
         workflow.add_edge("aggregate_stats", "format_response")
         workflow.add_edge("format_response", END)
-        
+
         return workflow.compile()
-    
+
     async def _extract_query_details(self, state: WorkflowState) -> WorkflowState:
         """
         Initial Node: Extract the desired statistic and query details
         """
         messages = [
-            SystemMessage(content="""
+            SystemMessage(
+                content="""
             You are analyzing a sports query to extract key details for league leaders analysis.
-            
+
             Extract:
             1. The main statistic being requested (e.g., "sacks", "touchdowns", "passing yards")
             2. Any position filters (e.g., "quarterbacks", "defensive ends")
             3. Season/time filters
             4. The sport being queried
-            
+
             Respond with a JSON object containing these details.
-            """),
-            HumanMessage(content=f"Query: {state.get('messages', [])[-1].get('content', '')}")
+            """
+            ),
+            HumanMessage(
+                content=f"Query: {state.get('messages', [])[-1].get('content', '')}"
+            ),
         ]
-        
+
         response = await self.llm.ainvoke(messages)
-        
+
         # Parse the LLM response (simplified for now)
         # In a full implementation, you'd use structured output parsing
         state["step_count"] = state.get("step_count", 0) + 1
         state["processed_data"]["query_analysis"] = response.content
-        
+
         return state
-    
+
     async def _fetch_teams(self, state: WorkflowState) -> WorkflowState:
         """
         Team Fetch Node: Get all teams for the sport
         """
         sport_context = SportContext(sport=state["sport"], season=state.get("season"))
-        
+
         # Use the LangChain tool
         team_tool = FetchTeamListingTool()
         teams_result = team_tool._run(sport_context)
-        
+
         if teams_result["success"]:
             state["raw_data"]["teams"] = teams_result["teams"]
         else:
-            state["errors"].append(f"Failed to fetch teams: {teams_result.get('error')}")
-        
+            state["errors"].append(
+                f"Failed to fetch teams: {teams_result.get('error')}"
+            )
+
         state["step_count"] += 1
         return state
-    
+
     async def _fetch_player_data(self, state: WorkflowState) -> WorkflowState:
         """
         Player Data Fetch Node: Get player statistics (parallel processing)
-        
+
         This would ideally use parallel processing for multiple players,
         but simplified here for demonstration.
         """
         teams = state["raw_data"].get("teams", [])
         sport_context = SportContext(sport=state["sport"], season=state.get("season"))
-        
+
         player_stats = []
         stats_tool = FetchPlayerStatsTool()
-        
-        # In a real implementation, this would be parallelized
-        # and would fetch rosters first, then individual player stats
+        cache = get_cache_instance()
+        sport = state["sport"]
+        sport_conf = api_config.get(sport, {})
+        base_url = sport_conf.get("base_url")
+        roster_endpoint = sport_conf.get("endpoints", {}).get("PlayersByTeam")
+        headers = sport_conf.get("headers", {})
+
+        # Fetch real rosters via API and gather player stats
         for team in teams[:3]:  # Limit for demo
-            # This is simplified - normally you'd fetch team rosters first
-            team_name = team.get("name", "")
-            if team_name:
-                # Mock player data for demonstration
-                mock_players = [f"{team_name} Player 1", f"{team_name} Player 2"]
-                
-                for player_name in mock_players:
-                    try:
-                        result = stats_tool._run(
-                            player_name=player_name,
-                            sport_context=sport_context,
-                            metrics=state.get("metrics", [])
-                        )
-                        if result["success"]:
-                            player_stats.append(result)
-                    except Exception as e:
-                        state["errors"].append(f"Error fetching {player_name}: {str(e)}")
-        
+            team_id = str(
+                team.get("id") or team.get("teamId") or team.get("abbreviation")
+            )
+            if not team_id:
+                continue
+
+            roster = cache.get_roster(sport, team_id)
+            if not roster and base_url and roster_endpoint:
+                try:
+                    url = f"{base_url}{roster_endpoint}"
+                    resp = requests.get(
+                        url, headers=headers, params={"id": team_id}, timeout=30
+                    )
+                    resp.raise_for_status()
+                    roster = resp.json()
+                    cache.set_roster(sport, team_id, roster)
+                except Exception as e:
+                    state["errors"].append(
+                        f"Roster fetch failed for {team_id}: {str(e)}"
+                    )
+                    continue
+
+            players = []
+            if isinstance(roster, list):
+                players = roster
+            elif isinstance(roster, dict):
+                players = (
+                    roster.get("athletes")
+                    or roster.get("players")
+                    or roster.get("playerList")
+                    or []
+                )
+
+            for player in players[:2]:
+                player_name = (
+                    player.get("displayName")
+                    or player.get("name")
+                    or player.get("fullName")
+                )
+                if not player_name:
+                    continue
+                try:
+                    result = stats_tool._run(
+                        player_name=player_name,
+                        sport_context=sport_context,
+                        metrics=state.get("metrics", []),
+                    )
+                    if result["success"]:
+                        player_stats.append(result)
+                except Exception as e:
+                    state["errors"].append(f"Error fetching {player_name}: {str(e)}")
+
         state["raw_data"]["player_stats"] = player_stats
         state["step_count"] += 1
         return state
-    
+
     async def _aggregate_stats(self, state: WorkflowState) -> WorkflowState:
         """
         Aggregation Node: Filter, aggregate, and sort player statistics
-        
+
         This is where your existing custom aggregation logic would be integrated.
         """
         player_stats = state["raw_data"].get("player_stats", [])
         metrics = state.get("metrics", [])
-        
+
         # Simplified aggregation logic
         # In reality, this would use your existing StatRetrieverApiAgent logic
         aggregated_results = []
-        
+
         for stat_data in player_stats:
             if stat_data.get("success"):
                 # Extract relevant metrics
                 player_name = stat_data.get("player_name")
                 data = stat_data.get("data", {})
-                
+
                 # This would be replaced with your actual stat extraction logic
-                aggregated_results.append({
-                    "player": player_name,
-                    "sport": state["sport"],
-                    "metrics": data  # Simplified
-                })
-        
+                aggregated_results.append(
+                    {
+                        "player": player_name,
+                        "sport": state["sport"],
+                        "metrics": data,  # Simplified
+                    }
+                )
+
         # Sort by the primary metric (simplified)
         # Your existing logic would handle complex sorting
         state["processed_data"]["aggregated_stats"] = aggregated_results
         state["step_count"] += 1
         return state
-    
+
     async def _format_response(self, state: WorkflowState) -> WorkflowState:
         """
         Response Formatting Node: Format results for user presentation
         """
         aggregated_stats = state["processed_data"].get("aggregated_stats", [])
-        
+
         # Use LLM to format the response
         format_prompt = f"""
         Format these league leader statistics into a user-friendly response:
-        
+
         Sport: {state['sport']}
         Query Type: League Leaders
         Data: {aggregated_stats}
-        
+
         Create a clear, engaging summary of the top performers.
         """
-        
+
         messages = [
-            SystemMessage(content="You are a sports analyst creating engaging summaries of statistical data."),
-            HumanMessage(content=format_prompt)
+            SystemMessage(
+                content="You are a sports analyst creating engaging summaries of statistical data."
+            ),
+            HumanMessage(content=format_prompt),
         ]
-        
+
         response = await self.llm.ainvoke(messages)
-        
+
         state["results"]["formatted_response"] = response.content
         state["results"]["raw_stats"] = aggregated_stats
         state["step_count"] += 1
-        
+
         return state
-    
-    async def execute(self, query: str, sport: str, season: str = None) -> Dict[str, Any]:
+
+    async def execute(
+        self, query: str, sport: str, season: str = None
+    ) -> Dict[str, Any]:
         """
         Execute the league leaders workflow
         """
@@ -250,9 +306,9 @@ class LeagueLeadersWorkflow:
             results={},
             errors=[],
             step_count=0,
-            max_steps=10
+            max_steps=10,
         )
-        
+
         final_state = await self.workflow.ainvoke(initial_state)
         return final_state
 
@@ -260,28 +316,30 @@ class LeagueLeadersWorkflow:
 class DebateWorkflow:
     """
     LangGraph workflow for Player Debate/Comparison.
-    
+
     This implements the multi-agent debate engine described in the architectural review,
     with specialized agents for different perspectives.
     """
-    
+
     def __init__(self, llm_model: str = "gpt-4o-mini"):
-        self.llm = ChatOpenAI(model=llm_model, temperature=0.7)  # Higher temp for creativity
+        self.llm = ChatOpenAI(
+            model=llm_model, temperature=0.7
+        )  # Higher temp for creativity
         self.tools = SPORTS_TOOLS
         self.workflow = self._build_debate_workflow()
-    
+
     def _build_debate_workflow(self) -> StateGraph:
         """Build the debate workflow with specialized agents"""
-        
+
         workflow = StateGraph(WorkflowState)
-        
+
         # Add specialized agent nodes
         workflow.add_node("prepare_debate", self._prepare_debate)
         workflow.add_node("advocate_agent", self._advocate_agent)
         workflow.add_node("critic_agent", self._critic_agent)
         workflow.add_node("moderator_agent", self._moderator_agent)
         workflow.add_node("evidence_collector", self._evidence_collector)
-        
+
         # Define the debate flow
         workflow.set_entry_point("prepare_debate")
         workflow.add_edge("prepare_debate", "evidence_collector")
@@ -289,166 +347,176 @@ class DebateWorkflow:
         workflow.add_edge("advocate_agent", "critic_agent")
         workflow.add_edge("critic_agent", "moderator_agent")
         workflow.add_edge("moderator_agent", END)
-        
+
         return workflow.compile()
-    
+
     async def _prepare_debate(self, state: WorkflowState) -> WorkflowState:
         """Prepare the debate by identifying players and context"""
-        
+
         query = state["messages"][-1]["content"]
-        
+
         # Extract players to compare using LLM
         extraction_prompt = f"""
         Extract the players being compared in this query: "{query}"
-        
+
         Respond with a JSON object containing:
         - player1: first player name
         - player2: second player name
         - comparison_aspect: what aspect is being compared
         - sport: which sport
         """
-        
+
         messages = [
-            SystemMessage(content="You extract player comparison details from sports queries."),
-            HumanMessage(content=extraction_prompt)
+            SystemMessage(
+                content="You extract player comparison details from sports queries."
+            ),
+            HumanMessage(content=extraction_prompt),
         ]
-        
+
         response = await self.llm.ainvoke(messages)
-        
+
         # Parse response (simplified)
         state["processed_data"]["debate_setup"] = response.content
         state["step_count"] = state.get("step_count", 0) + 1
-        
+
         return state
-    
+
     async def _evidence_collector(self, state: WorkflowState) -> WorkflowState:
         """Collect statistical evidence for both players"""
-        
+
         # This would use the FetchPlayerStatsTool for both players
         player_names = state.get("player_names", [])
         sport_context = SportContext(sport=state["sport"], season=state.get("season"))
-        
+
         stats_tool = FetchPlayerStatsTool()
         evidence = {}
-        
+
         for player in player_names:
             try:
                 result = stats_tool._run(
                     player_name=player,
                     sport_context=sport_context,
-                    metrics=state.get("metrics", [])
+                    metrics=state.get("metrics", []),
                 )
                 evidence[player] = result
             except Exception as e:
                 state["errors"].append(f"Failed to get stats for {player}: {str(e)}")
-        
+
         state["raw_data"]["evidence"] = evidence
         state["step_count"] += 1
-        
+
         return state
-    
+
     async def _advocate_agent(self, state: WorkflowState) -> WorkflowState:
         """
         Advocate Agent: Present the strongest case for player comparison
-        
+
         This implements the "bull agent" pattern from the architectural review.
         """
         evidence = state["raw_data"].get("evidence", {})
-        
+
         advocate_prompt = f"""
         You are an advocate presenting the strongest statistical case for player comparison.
-        
+
         Evidence: {evidence}
-        
+
         Present compelling arguments highlighting the strengths and achievements of each player.
         Use specific statistics and context to build your case.
         """
-        
+
         messages = [
-            SystemMessage(content="You are a passionate sports advocate who builds compelling cases using statistics."),
-            HumanMessage(content=advocate_prompt)
+            SystemMessage(
+                content="You are a passionate sports advocate who builds compelling cases using statistics."
+            ),
+            HumanMessage(content=advocate_prompt),
         ]
-        
+
         response = await self.llm.ainvoke(messages)
-        
+
         state["processed_data"]["advocate_argument"] = response.content
         state["step_count"] += 1
-        
+
         return state
-    
+
     async def _critic_agent(self, state: WorkflowState) -> WorkflowState:
         """
         Critic Agent: Present counterarguments and analysis
-        
+
         This implements the "bear agent" pattern from the architectural review.
         """
         advocate_argument = state["processed_data"].get("advocate_argument", "")
         evidence = state["raw_data"].get("evidence", {})
-        
+
         critic_prompt = f"""
         You are a critical analyst reviewing this player comparison argument:
-        
+
         Original Argument: {advocate_argument}
         Evidence: {evidence}
-        
+
         Provide critical analysis, counterarguments, and point out any weaknesses or missing context.
         Highlight areas where one player might have advantages over another.
         """
-        
+
         messages = [
-            SystemMessage(content="You are a critical sports analyst who provides balanced, skeptical analysis."),
-            HumanMessage(content=critic_prompt)
+            SystemMessage(
+                content="You are a critical sports analyst who provides balanced, skeptical analysis."
+            ),
+            HumanMessage(content=critic_prompt),
         ]
-        
+
         response = await self.llm.ainvoke(messages)
-        
+
         state["processed_data"]["critic_analysis"] = response.content
         state["step_count"] += 1
-        
+
         return state
-    
+
     async def _moderator_agent(self, state: WorkflowState) -> WorkflowState:
         """
         Moderator Agent: Synthesize arguments and provide balanced conclusion
-        
+
         This implements the "chairman agent" pattern from the architectural review.
         """
         advocate_arg = state["processed_data"].get("advocate_argument", "")
         critic_analysis = state["processed_data"].get("critic_analysis", "")
         evidence = state["raw_data"].get("evidence", {})
-        
+
         moderator_prompt = f"""
         You are a neutral moderator synthesizing this player comparison debate:
-        
+
         Advocate Position: {advocate_arg}
         Critical Analysis: {critic_analysis}
         Statistical Evidence: {evidence}
-        
+
         Provide a balanced, nuanced conclusion that acknowledges both perspectives
         and gives a fair assessment based on the available evidence.
         """
-        
+
         messages = [
-            SystemMessage(content="You are a balanced sports moderator who synthesizes different perspectives fairly."),
-            HumanMessage(content=moderator_prompt)
+            SystemMessage(
+                content="You are a balanced sports moderator who synthesizes different perspectives fairly."
+            ),
+            HumanMessage(content=moderator_prompt),
         ]
-        
+
         response = await self.llm.ainvoke(messages)
-        
+
         state["results"]["final_debate"] = {
             "advocate_position": advocate_arg,
             "critical_analysis": critic_analysis,
             "moderator_conclusion": response.content,
-            "evidence_used": evidence
+            "evidence_used": evidence,
         }
-        
+
         state["step_count"] += 1
-        
+
         return state
-    
-    async def execute(self, query: str, sport: str, player_names: List[str]) -> Dict[str, Any]:
+
+    async def execute(
+        self, query: str, sport: str, player_names: List[str]
+    ) -> Dict[str, Any]:
         """Execute the debate workflow"""
-        
+
         initial_state = WorkflowState(
             messages=[{"role": "user", "content": query}],
             sport=sport,
@@ -462,9 +530,9 @@ class DebateWorkflow:
             results={},
             errors=[],
             step_count=0,
-            max_steps=10
+            max_steps=10,
         )
-        
+
         final_state = await self.workflow.ainvoke(initial_state)
         return final_state
 
@@ -472,39 +540,45 @@ class DebateWorkflow:
 class WorkflowOrchestrator:
     """
     Main orchestrator for selecting and executing appropriate workflows.
-    
+
     This provides the entry point for the hybrid LangChain/LangGraph system.
     """
-    
+
     def __init__(self):
         self.league_leaders_workflow = LeagueLeadersWorkflow()
         self.debate_workflow = DebateWorkflow()
-    
-    async def execute_query(self, query: str, query_type: str, **kwargs) -> Dict[str, Any]:
+
+    async def execute_query(
+        self, query: str, query_type: str, **kwargs
+    ) -> Dict[str, Any]:
         """
         Execute the appropriate workflow based on query type
         """
-        
+
         if query_type == "league_leaders":
             return await self.league_leaders_workflow.execute(
                 query=query,
                 sport=kwargs.get("sport", "NFL"),
-                season=kwargs.get("season")
+                season=kwargs.get("season"),
             )
-        
+
         elif query_type == "player_debate" or query_type == "player_comparison":
             return await self.debate_workflow.execute(
                 query=query,
                 sport=kwargs.get("sport", "NFL"),
-                player_names=kwargs.get("player_names", [])
+                player_names=kwargs.get("player_names", []),
             )
-        
+
         else:
             return {
                 "error": f"Unsupported query type: {query_type}",
-                "supported_types": ["league_leaders", "player_debate", "player_comparison"]
+                "supported_types": [
+                    "league_leaders",
+                    "player_debate",
+                    "player_comparison",
+                ],
             }
-    
+
     def get_available_workflows(self) -> List[str]:
         """Get list of available workflow types"""
-        return ["league_leaders", "player_debate", "player_comparison"] 
+        return ["league_leaders", "player_debate", "player_comparison"]

--- a/src/sports_bot/workflows/simple_data_flow.py
+++ b/src/sports_bot/workflows/simple_data_flow.py
@@ -3,29 +3,34 @@
 LangGraph-powered but with linear flow to avoid recursion
 """
 
-from typing import Dict, List, Any, Optional
 import asyncio
 import logging
-from ..stats.universal_stat_retriever import UniversalStatRetriever
+from typing import Any, Dict, List, Optional
+
+from ..agents.sports_agents import QueryContext
 from ..cache.shared_cache import get_cache_instance
+from ..stats.universal_stat_retriever import UniversalStatRetriever
 
 logger = logging.getLogger(__name__)
 
+
 class SimpleDataFlow:
     """Simplified data flow without complex routing to avoid recursion"""
-    
+
     def __init__(self):
         self.stat_retriever = UniversalStatRetriever()
         self.cache = get_cache_instance()
-    
-    async def gather_debate_data(self, query_context: Dict[str, Any], debate_topic: str) -> Dict[str, Any]:
+
+    async def gather_debate_data(
+        self, query_context: Dict[str, Any], debate_topic: str
+    ) -> Dict[str, Any]:
         """Simple linear data gathering"""
-        
+
         logger.info(f"🚀 Simple data flow for: {debate_topic}")
-        
+
         gathered_data = {}
         sport = query_context.get("sport", "NFL")
-        
+
         # Step 1: Try cache first
         for player_name in query_context.get("player_names", []):
             cached_player = self.cache.get_player(sport, player_name)
@@ -33,49 +38,55 @@ class SimpleDataFlow:
                 player_id = cached_player.get("id", cached_player.get("external_id"))
                 if player_id:
                     cached_stats = self.cache.get_stats(
-                        sport, str(player_id), "2024", 
-                        query_context.get("metrics_needed", [])
+                        sport,
+                        str(player_id),
+                        "2024",
+                        query_context.get("metrics_needed", []),
                     )
                     if cached_stats:
                         gathered_data[f"player_{player_name}"] = cached_stats
                         continue
-            
-            # Step 2: Try database if cache miss
-            mock_context = type('MockContext', (), {
-                'sport': sport,
-                'player_names': [player_name],
-                'metrics_needed': query_context.get("metrics_needed", []),
-                'season_years': query_context.get("season_years", []),
-                'strategy': query_context.get("strategy", ""),
-            })()
-            
-            player_data = self.stat_retriever.fetch_stats(mock_context)
+
+            # Step 2: Try database if cache miss using real QueryContext
+            real_context = QueryContext(
+                question=f"Get stats for {player_name}",
+                sport=sport,
+                player_names=[player_name],
+                metrics_needed=query_context.get("metrics_needed", []),
+                season_years=query_context.get("season_years", []),
+                strategy=query_context.get("strategy", ""),
+            )
+
+            player_data = self.stat_retriever.fetch_stats(real_context)
             if player_data and "error" not in player_data:
                 gathered_data[f"player_{player_name}"] = player_data
-                
+
                 # Cache the result
                 player_id = player_data.get("player_id", "")
                 if player_id:
                     self.cache.set_stats(
-                        sport, player_id, "2024",
-                        query_context.get("metrics_needed", []), 
-                        player_data
+                        sport,
+                        player_id,
+                        "2024",
+                        query_context.get("metrics_needed", []),
+                        player_data,
                     )
-        
+
         # Handle league leaders
         if query_context.get("strategy") == "leaderboard_query":
-            mock_context = type('MockContext', (), {
-                'sport': sport,
-                'player_names': [],
-                'metrics_needed': query_context.get("metrics_needed", []),
-                'season_years': query_context.get("season_years", []),
-                'strategy': "leaderboard_query",
-            })()
-            
-            leaders_data = self.stat_retriever.fetch_league_leaders(mock_context)
+            leaders_context = QueryContext(
+                question=f"{debate_topic} leaderboard",
+                sport=sport,
+                player_names=[],
+                metrics_needed=query_context.get("metrics_needed", []),
+                season_years=query_context.get("season_years", []),
+                strategy="leaderboard_query",
+            )
+
+            leaders_data = self.stat_retriever.fetch_league_leaders(leaders_context)
             if leaders_data and "error" not in leaders_data:
                 gathered_data["league_leaders"] = leaders_data
-        
+
         # Return result
         return {
             "status": "complete" if gathered_data else "failed",
@@ -86,26 +97,29 @@ class SimpleDataFlow:
                 "entities_gathered": len(gathered_data),
             },
             "summary": {
-                "success_rate": len(gathered_data) / max(1, len(query_context.get("player_names", [])))
-            }
+                "success_rate": len(gathered_data)
+                / max(1, len(query_context.get("player_names", [])))
+            },
         }
+
 
 class SimpleLangGraphConnector:
     """Simple connector without recursion issues"""
-    
+
     def __init__(self):
         self.data_flow = SimpleDataFlow()
-    
-    async def prepare_debate_data(self, topic: str, context: Dict[str, Any]) -> Dict[str, Any]:
+
+    async def prepare_debate_data(
+        self, topic: str, context: Dict[str, Any]
+    ) -> Dict[str, Any]:
         """Prepare data using simple linear flow"""
-        
+
         print(f"🧠 **Simple Data Flow**: Analyzing '{topic}'")
         result = await self.data_flow.gather_debate_data(context, topic)
-        
+
         if result["status"] == "complete":
             print(f"✅ **Data Ready**: {len(result['data'])} data sources gathered")
         else:
             print(f"⚠️ **Partial Data**: Some data sources failed")
-        
-        return result
 
+        return result


### PR DESCRIPTION
## Summary
- remove temporary MockContext objects in simple_data_flow
- fetch team rosters from API in LangGraph workflows
- use QueryContext for stat retrieval

## Testing
- `pre-commit run --files src/sports_bot/workflows/simple_data_flow.py src/sports_bot/langchain_integration/workflows.py` *(fails: mypy errors)*
- `pytest tests/ -k "workflows" -q` *(errors: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6865cab3c2e48324b9cfdb75feebf253