### PR TITLE
Add datetime import to logging config

### DIFF
--- a/src/sports_bot/core/logging_config.py
+++ b/src/sports_bot/core/logging_config.py
@@ -4,6 +4,7 @@ Logging configuration for the sports bot.
 
 import logging
 import sys
+from datetime import datetime
 from typing import Optional
 
 def setup_logging(


### PR DESCRIPTION
## Summary
- import `datetime` in logging config so timestamps work

## Testing
- `pytest -q tests`

------
https://chatgpt.com/codex/tasks/task_e_6888171a905c8324a004d88e43f5c7fb