### PR TITLE
Refactor NFL debate agent bridge

### DIFF
--- a/src/sports_bot/agents/bridge.py
+++ b/src/sports_bot/agents/bridge.py
@@ -1,0 +1,145 @@
+import asyncio
+import json
+import sys
+
+from sports_bot.agents.debate_agent import (
+    DebateAgent,
+    DebateContext,
+    extract_player_names,
+    extract_team_names,
+    extract_metrics,
+    format_comparison_analysis,
+    generate_ranking_analysis,
+)
+
+
+async def main():
+    """Main function to handle Node.js communication for enhanced LangChain integration"""
+    try:
+        # Read JSON input from Node.js
+        input_data = json.loads(sys.stdin.read())
+
+        action = input_data.get('action')
+        context_data = input_data.get('context', {})
+
+        if action == 'test_connection':
+            result = {
+                'status': 'connected',
+                'agent_type': 'NFL Debate Agent',
+                'capabilities': [
+                    'Player comparisons',
+                    'Statistical analysis',
+                    'Team evaluations',
+                    'Context-aware debates',
+                    'Cardinality-aware processing'
+                ]
+            }
+        elif action == 'generateIntelligentDebate':
+            result = await handle_intelligent_debate(context_data)
+        elif action == 'generateGeneralAnalysis':
+            result = await handle_general_analysis(context_data)
+        else:
+            result = {
+                'error': f'Unknown action: {action}',
+                'available_actions': ['test_connection', 'generateIntelligentDebate', 'generateGeneralAnalysis']
+            }
+
+        # Output JSON result for Node.js
+        print(json.dumps(result))
+
+    except Exception as e:
+        error_result = {
+            'error': f'Python NFL agent error: {str(e)}',
+            'type': 'python_error'
+        }
+        print(json.dumps(error_result))
+
+
+async def handle_intelligent_debate(context_data: dict) -> dict:
+    """Handle intelligent debate generation with cardinality awareness"""
+
+    query = context_data.get('query', '')
+    sport = context_data.get('sport', 'NFL')
+    cardinality = context_data.get('cardinality', 'one-to-one')
+    entity_relationships = context_data.get('entityRelationships', [])
+
+    # Initialize debate agent
+    try:
+        agent = DebateAgent()
+
+        # Create context based on cardinality
+        debate_context = DebateContext(
+            query=query,
+            player_names=extract_player_names(query, entity_relationships),
+            team_names=extract_team_names(query, entity_relationships),
+            metrics=extract_metrics(query, entity_relationships),
+            time_period="2024 season"
+        )
+
+        # Generate debate based on cardinality
+        if cardinality == 'many-to-one':
+            # Comparison-focused debate
+            result = await agent.generate_debate(debate_context)
+            result['analysis'] = format_comparison_analysis(result, query)
+        elif cardinality == 'one-to-many':
+            # Ranking-focused analysis
+            result = await generate_ranking_analysis(query, entity_relationships)
+        else:
+            # Standard debate
+            result = await agent.generate_debate(debate_context)
+
+        return {
+            'type': 'intelligent_nfl_debate',
+            'analysis': result.get('analysis', result.get('conclusion', 'Analysis completed')),
+            'confidence': result.get('confidence', 0.85),
+            'sport': sport,
+            'query': query,
+            'cardinality': cardinality,
+            'agents_used': ['nfl_debate_agent', 'stats_analyzer'],
+            'metadata': {
+                'players_analyzed': result.get('players', []),
+                'stats_used': result.get('stats', {}),
+                'processing_method': 'langchain_intelligence'
+            }
+        }
+
+    except Exception as e:
+        return {
+            'type': 'nfl_debate_error',
+            'analysis': f"""🏈 **NFL Analysis Error**\n\nQuery: *\"{query}\"*\n\n**Error Processing:** {str(e)}\n\n**Fallback Available:** The system can provide basic NFL analysis through alternative routing.\n\n**Recommendation:** Try rephrasing the query or asking about specific players or teams.\n\n*NFL debate agent temporarily unavailable*""",
+            'confidence': 0.50,
+            'sport': sport,
+            'query': query,
+            'cardinality': cardinality,
+            'error': str(e)
+        }
+
+
+async def handle_general_analysis(context_data: dict) -> dict:
+    """Handle general NFL analysis with enhanced intelligence"""
+
+    query = context_data.get('query', '')
+    sport = context_data.get('sport', 'NFL')
+    cardinality = context_data.get('cardinality', 'one-to-one')
+    entity_relationships = context_data.get('entityRelationships', [])
+
+    # Simple but intelligent analysis
+    analysis = f"""🏈 **NFL General Analysis**\n\nQuery: *\"{query}\"*\n\n**Intelligent Processing:**\n• Cardinality: {cardinality}\n• Entities: {', '.join(entity_relationships) if entity_relationships else 'General NFL'}\n• Analysis Type: Context-aware general analysis\n\n**NFL Intelligence:**\nThis query has been processed through the LangChain NFL agent with enhanced understanding of relationships and context.\n\n**Available Analysis:**\n- Player performance metrics\n- Team success factors\n- Statistical comparisons\n- Contextual insights\n\n**Recommendation:**\nFor more detailed analysis, try specific player or team queries with comparative elements.\n\n*Powered by LangChain NFL Intelligence*"""
+
+    return {
+        'type': 'nfl_general_analysis',
+        'analysis': analysis,
+        'confidence': 0.80,
+        'sport': sport,
+        'query': query,
+        'cardinality': cardinality,
+        'agents_used': ['nfl_general_agent'],
+        'metadata': {
+            'processing_type': 'general_analysis',
+            'intelligence_level': 'enhanced'
+        }
+    }
+
+
+if __name__ == '__main__':
+    asyncio.run(main())

--- a/src/sports_bot/agents/debate_agent.py
+++ b/src/sports_bot/agents/debate_agent.py
@@ -341,7 +341,7 @@ class DebateAgent:
                             }
                             for p in roster["athletes"][:5]  # Just first 5 players
                         ]
-                        
+
             # Search players by iterating through team rosters
             for team_data in teams:
                 team_id = team_data["team"]["id"]
@@ -451,170 +451,10 @@ class DebateAgent:
                                         }
                                         for p in roster["athletes"][:5]  # Just first 5 players
                                     ]
-                                
+
         logger.debug(f"Generated debate data: {debate_data}")
         return debate_data
-
-# Node.js Bridge Integration
-async def main():
-    """Main function to handle Node.js communication for enhanced LangChain integration"""
-    import json
-    import sys
-    
-    try:
-        # Read JSON input from Node.js
-        input_data = json.loads(sys.stdin.read())
-        
-        action = input_data.get('action')
-        context_data = input_data.get('context', {})
-        
-        if action == 'test_connection':
-            result = {
-                'status': 'connected',
-                'agent_type': 'NFL Debate Agent',
-                'capabilities': [
-                    'Player comparisons',
-                    'Statistical analysis',
-                    'Team evaluations',
-                    'Context-aware debates',
-                    'Cardinality-aware processing'
-                ]
-            }
-        elif action == 'generateIntelligentDebate':
-            result = await handle_intelligent_debate(context_data)
-        elif action == 'generateGeneralAnalysis':
-            result = await handle_general_analysis(context_data)
-        else:
-            result = {
-                'error': f'Unknown action: {action}',
-                'available_actions': ['test_connection', 'generateIntelligentDebate', 'generateGeneralAnalysis']
-            }
-        
-        # Output JSON result for Node.js
-        print(json.dumps(result))
-        
-    except Exception as e:
-        error_result = {
-            'error': f'Python NFL agent error: {str(e)}',
-            'type': 'python_error'
-        }
-        print(json.dumps(error_result))
-
-async def handle_intelligent_debate(context_data: dict) -> dict:
-    """Handle intelligent debate generation with cardinality awareness"""
-    
-    query = context_data.get('query', '')
-    sport = context_data.get('sport', 'NFL')
-    cardinality = context_data.get('cardinality', 'one-to-one')
-    entity_relationships = context_data.get('entityRelationships', [])
-    
-    # Initialize debate agent
-    try:
-        agent = DebateAgent()
-        
-        # Create context based on cardinality
-        debate_context = DebateContext(
-            query=query,
-            player_names=extract_player_names(query, entity_relationships),
-            team_names=extract_team_names(query, entity_relationships),
-            metrics=extract_metrics(query, entity_relationships),
-            time_period="2024 season"
-        )
-        
-        # Generate debate based on cardinality
-        if cardinality == 'many-to-one':
-            # Comparison-focused debate
-            result = await agent.generate_debate(debate_context)
-            result['analysis'] = format_comparison_analysis(result, query)
-        elif cardinality == 'one-to-many':
-            # Ranking-focused analysis
-            result = await generate_ranking_analysis(query, entity_relationships)
-        else:
-            # Standard debate
-            result = await agent.generate_debate(debate_context)
-            
-        return {
-            'type': 'intelligent_nfl_debate',
-            'analysis': result.get('analysis', result.get('conclusion', 'Analysis completed')),
-            'confidence': result.get('confidence', 0.85),
-            'sport': 'NFL',
-            'query': query,
-            'cardinality': cardinality,
-            'agents_used': ['nfl_debate_agent', 'stats_analyzer'],
-            'metadata': {
-                'players_analyzed': result.get('players', []),
-                'stats_used': result.get('stats', {}),
-                'processing_method': 'langchain_intelligence'
-            }
-        }
-        
-    except Exception as e:
-        return {
-            'type': 'nfl_debate_error',
-            'analysis': f"""🏈 **NFL Analysis Error**
-
-Query: *"{query}"*
-
-**Error Processing:** {str(e)}
-
-**Fallback Available:** The system can provide basic NFL analysis through alternative routing.
-
-**Recommendation:** Try rephrasing the query or asking about specific players or teams.
-
-*NFL debate agent temporarily unavailable*""",
-            'confidence': 0.50,
-            'sport': 'NFL',
-            'query': query,
-            'cardinality': cardinality,
-            'error': str(e)
-        }
-
-async def handle_general_analysis(context_data: dict) -> dict:
-    """Handle general NFL analysis with enhanced intelligence"""
-    
-    query = context_data.get('query', '')
-    sport = context_data.get('sport', 'NFL')
-    cardinality = context_data.get('cardinality', 'one-to-one')
-    entity_relationships = context_data.get('entityRelationships', [])
-    
-    # Simple but intelligent analysis
-    analysis = f"""🏈 **NFL General Analysis**
-
-Query: *"{query}"*
-
-**Intelligent Processing:**
-• Cardinality: {cardinality}
-• Entities: {', '.join(entity_relationships) if entity_relationships else 'General NFL'}
-• Analysis Type: Context-aware general analysis
-
-**NFL Intelligence:**
-This query has been processed through the LangChain NFL agent with enhanced understanding of relationships and context.
-
-**Available Analysis:**
-- Player performance metrics
-- Team success factors  
-- Statistical comparisons
-- Contextual insights
-
-**Recommendation:**
-For more detailed analysis, try specific player or team queries with comparative elements.
-
-*Powered by LangChain NFL Intelligence*"""
-
-    return {
-        'type': 'nfl_general_analysis',
-        'analysis': analysis,
-        'confidence': 0.80,
-        'sport': 'NFL',
-        'query': query,
-        'cardinality': cardinality,
-        'agents_used': ['nfl_general_agent'],
-        'metadata': {
-            'processing_type': 'general_analysis',
-            'intelligence_level': 'enhanced'
-        }
-    }
-
+                                
 def extract_player_names(query: str, entities: list) -> list:
     """Extract player names from query and entities"""
     # Simple extraction - in real implementation would use NLP
@@ -690,7 +530,3 @@ The ranking system has processed multiple candidates and applied weighted evalua
         'confidence': 0.82,
         'type': 'ranking_analysis'
     }
-
-if __name__ == '__main__':
-    import asyncio
-    asyncio.run(main())


### PR DESCRIPTION
## Summary
- move Node.js bridge functions to `bridge.py`
- keep `debate_agent.py` focused on agent logic

## Testing
- `pip install -q -r requirements.txt`
- `PYTHONPATH=src pytest -q tests/test_debate_agent.py`

------
https://chatgpt.com/codex/tasks/task_e_6888172b019c8324a22509e72f34d223